### PR TITLE
Install python3.x if runner OS is Ubuntu24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - if: ${{ github.ImageOS == 'Ubuntu24' }}
+      uses: actions/setup-python@v5
+      with:
+      python-version: '3.x'
     - id: install
       run: ${{ github.action_path }}/install.sh "${{ inputs.version }}" "${{ inputs.installed_path }}"
       shell: bash


### PR DESCRIPTION
Github are currently in the process of rolling out Ubuntu 24.x as the new `ubuntu-latest` OS.

The Ubuntu 24.x runner image seems to have a broken Python installation where pip packages can't be installed system-wide, see: https://github.com/actions/runner-images/issues/10636#issuecomment-2377530635

This PR alleviates the issue by installing Python3.x if the runner ImageOS == Ubuntu24.